### PR TITLE
remove tableausdk requirement, add backwards compatibility

### DIFF
--- a/build/lib/pandleau/pandleau.py
+++ b/build/lib/pandleau/pandleau.py
@@ -52,7 +52,11 @@ class pandleau( object ):
                       'period':Type.DURATION,
                       'mixed':Type.UNICODE_STRING}
             try:
-            	return mapper[pandas.api.types.infer_dtype(column.dropna())]
+                # Use pandas api for inferring types for latest versions of pandas, lib method for earlier versions
+                if pandas.__version__ >= '0.21.0':
+            	    return mapper[pandas.api.types.infer_dtype(column.dropna())]
+                else:
+                    return mapper[pandas.lib.infer_dtype(column.dropna())]
             except:
                 raise Exception('Error: Unknown pandas to Tableau data type.')
     

--- a/pandleau.egg-info/PKG-INFO
+++ b/pandleau.egg-info/PKG-INFO
@@ -3,7 +3,7 @@ Name: pandleau
 Version: 0.3.2
 Summary: A quick and easy way to convert a Pandas DataFrame to a Tableau extract.
 Home-page: https://github.com/bwiley1/pandleau
-Author: Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>
+Author: Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>, Aaron Wiegel <aawiegel@gmail.com>
 Author-email: UNKNOWN
 License: MIT
 Download-URL: https://github.com/bwiley1/pandleau/dist/pandleau-0.3.1.tar.gz

--- a/pandleau.egg-info/PKG-INFO
+++ b/pandleau.egg-info/PKG-INFO
@@ -1,12 +1,12 @@
 Metadata-Version: 1.1
 Name: pandleau
-Version: 0.3.1
+Version: 0.3.2
 Summary: A quick and easy way to convert a Pandas DataFrame to a Tableau extract.
 Home-page: https://github.com/bwiley1/pandleau
 Author: Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>
 Author-email: UNKNOWN
 License: MIT
-Download-URL: https://github.com/bwiley1/pandleau/dist/pandleau-0.3.tar.gz
+Download-URL: https://github.com/bwiley1/pandleau/dist/pandleau-0.3.1.tar.gz
 Description: # pandleau
         
         A quick and easy way to convert a Pandas DataFrame to a Tableau .tde or .hyper extract.

--- a/pandleau.egg-info/requires.txt
+++ b/pandleau.egg-info/requires.txt
@@ -1,3 +1,2 @@
 pandas
 numpy
-tableausdk

--- a/pandleau/pandleau.py
+++ b/pandleau/pandleau.py
@@ -2,18 +2,19 @@
 """
 
 
-@author: jamin, zhiruiwang
+@author: jamin, zhiruiwang, aawiegel
 """
 
 from __future__ import print_function
 import pandas
-import numpy
 from tableausdk import *
+
 try:
 	from tableausdk.Extract import *
 	print("You are using the Tableau SDK, please save the output as .tde format")
 except:
 	pass
+
 try:
 	from tableausdk.HyperExtract import *
 	print("You are using the Extract API 2.0, please save the output as .hyper format")
@@ -52,7 +53,11 @@ class pandleau( object ):
                       'period':Type.DURATION,
                       'mixed':Type.UNICODE_STRING}
             try:
-            	return mapper[pandas.api.types.infer_dtype(column.dropna())]
+                # Use pandas api for inferring types for latest versions of pandas, lib method for earlier versions
+                if pandas.__version__ >= '0.21.0':
+            	    return mapper[pandas.api.types.infer_dtype(column.dropna())]
+                else:
+                    return mapper[pandas.lib.infer_dtype(column.dropna())]
             except:
                 raise Exception('Error: Unknown pandas to Tableau data type.')
     

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@ from setuptools import setup, find_packages
 
 
 setup(name='pandleau',
-      version='0.3.1',
+      version='0.3.2',
       packages=find_packages(exclude=['tests*']),
       license='MIT',
       description='A quick and easy way to convert a Pandas DataFrame to a Tableau extract.',
       long_description=open('README.md').read(),
-      install_requires=['pandas','numpy','tableausdk'],
-      author='Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>',
+      install_requires=['pandas','numpy'],
+      author='Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>,'
+             'Aaron Wiegel <aawiegel@gmail.com>',
       url='https://github.com/bwiley1/pandleau',
       download_url='https://github.com/bwiley1/pandleau/dist/pandleau-0.3.1.tar.gz',
       py_modules=['pandleau'],


### PR DESCRIPTION
- Removed tableausdk requirement for now until it is pip installable
- Added handling for old versions of pandas (<0.21.0) where `infer_dtypes()` method was buried in cython library