### PR TITLE
updated deletion of old log and temp files

### DIFF
--- a/pandleau/pandleau.py
+++ b/pandleau/pandleau.py
@@ -6,6 +6,7 @@
 """
 
 from __future__ import print_function
+from glob import glob
 import pandas
 from tableausdk import *
 from tqdm import tqdm
@@ -126,10 +127,12 @@ class pandleau(object):
         @param add_index = adds incrementing integer index before dataframe columns
 
         """
+        
+        # Delete dataextract log and hyper_db temp files if already exists
+        files = (glob('DataExtract*.log') + glob('hyper_db_*')
+                 + [os.path.dirname(path) + '/debug.log', './DataExtract.log', './debug.log'])
 
-        # Delete debug log if already exists
-        for file in [os.path.dirname(path) + '/debug.log',
-                     './DataExtract.log', './debug.log']:
+        for file in files:
             if os.path.isfile(file):
                 os.remove(file)
 


### PR DESCRIPTION
Tableau Extract API 2.0 writes log and temp files with random suffixes e.g. `DataExtract_ivLPhOiC.log`, `hyper_db_2lVKam3k`. The current method of deleting existing log files in `to_tableau` method doesn't get these files.