### PR TITLE
auto install tableau sdk when installing pandleau with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,25 @@
+import platform
 from setuptools import setup, find_packages
 
+_tableausdk_hyper_system = {
+    'Windows': 'https://downloads.tableau.com/tssoftware/extractapi-py-x64-2019-2-6.zip',
+    'Darwin': 'https://downloads.tableau.com/tssoftware/extractapi-py-osx64-2019-2-6.tar.gz',
+    'Linux': 'https://downloads.tableau.com/tssoftware/extractapi-py-linux-x86_64-2019-2-6.tar.gz'
+}
+
+_tableausdk_tde_system = {
+    'Windows': 'https://downloads.tableau.com/tssoftware/Tableau-SDK-Python-Win-64Bit-10-3-26.zip',
+    'Darwin': 'https://downloads.tableau.com/tssoftware/Tableau-SDK-Python-OSX-64Bit-10-3-26.tar.gz',
+    'Linux': 'https://downloads.tableau.com/tssoftware/Tableau-SDK-Python-Linux-64Bit-10-3-26.tar.gz'
+}
+
+
+def _build_non_pypi_extra_uri(urimap):
+    return 'tableausdk @ ' + urimap[platform.system()] + '#egg=tableausdk'
+
+
+_hyper_dep_uri = _build_non_pypi_extra_uri(_tableausdk_hyper_system)
+_tde_dep_uri = _build_non_pypi_extra_uri(_tableausdk_tde_system)
 
 setup(name='pandleau',
       version='0.3.2-SNAPSHOT',
@@ -8,6 +28,10 @@ setup(name='pandleau',
       description='A quick and easy way to convert a Pandas DataFrame to a Tableau extract.',
       long_description=open('README.md').read(),
       install_requires=['pandas', 'numpy', 'tqdm'],
+      extras_require={
+          'tde': _tde_dep_uri,
+          'hyper': _hyper_dep_uri,
+      },
       author='Benjamin Wiley <bewi7122@colorado.edu>, Zhirui(Jerry) Wang <zw2389@columbia.edu>,'
              'Aaron Wiegel <aawiegel@gmail.com>',
       url='https://github.com/bwiley1/pandleau',


### PR DESCRIPTION
@bwiley1 - First I wanted to thank you, and the other contributors, for `pandleau`. It's a great utility and has been extremely helpful to me in some recent projects.  The goal of this PR is to help make get started using `pandleau` even easier by removing the need to download and install the TableauSDK's from Tableau's website. 

Within the `setup` function in `setup.py` it's possible to specify a keyword argument for `extras_require`, which provides an opportunity to optionally install additional libraries outside of direct dependencies of pandleau. 

To install `pandleau` + the desired tableausdk (hyper or tde), the interface from pip would look like the below.

PyPI

- `pip install pandleau[hyper]`

- `pip install pandleau[tde]`

GitHub

- `pip install git+https://github.com/bwiley1/pandleau.git#egg=pandleau[hyper]`

- `pip install git+https://github.com/bwiley1/pandleau.git#egg=pandleau[tde]`

Local Dev (assuming one is in the `pandleau` working directory)

- `pip install .[hyper]`

- `pip install .[tde]`

If a user has already downloaded the desired tableausdk, the standard `pip install pandleau` will still get them this package.

I don't have access to a Windows machine, but have tested on OS-X and am looking to test this implementation on a Linux box tomorrow.

It's worth noting there's a **_warning message_** thrown during install that doesn't impact the appropriate SDK being installed. 
```ERROR: Exception:
Traceback (most recent call last):
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 153, in _main
    status = self.run(options, args)
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 455, in run
    use_user_site=options.use_user_site,
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/req/__init__.py", line 62, in install_given_reqs
    **kwargs
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 861, in install
    use_user_site=use_user_site, pycompile=pycompile,
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 495, in move_wheel_files
    warn_script_location=warn_script_location,
  File "/Users/username/anaconda/envs/pandleau-dev-env/lib/python3.7/site-packages/pip/_internal/wheel.py", line 463, in move_wheel_files
    assert info_dir, "%s .dist-info directory not found" % req
AssertionError: tableausdk@ https://downloads.tableau.com/tssoftware/extractapi-py-osx64-2019-2-6.tar.gz#egg=tableausdk .dist-info directory not found```